### PR TITLE
Fix replace hardcoded 7pm to dynamic variable

### DIFF
--- a/src/components/NextEvent.tsx
+++ b/src/components/NextEvent.tsx
@@ -66,6 +66,10 @@ export default function NextEvent() {
     = todayDate.getMonth() === eventDate.getMonth()
     && todayDate.getDate() === eventDate.getDate()
 
+  const eventHour = eventDate.getHours() > 12 ? eventDate.getHours() - 12 : eventDate.getHours()
+  const eventMinutes = eventDate.getMinutes() > 0 ? `:${eventDate.getMinutes()}` : ''
+  const eventTime = eventDate.getHours() > 11 ? `${eventHour}${eventMinutes}pm` : `${eventHour}${eventMinutes}am`
+
   return (
     <div className="inner-section next-event">
       <h2>
@@ -73,7 +77,7 @@ export default function NextEvent() {
         {' '}
         <em>
           {isEventToday
-            ? 'Today 7pm'
+            ? `Today ${eventTime}`
             : eventDate.toLocaleString('en-us', {
               day: 'numeric',
               month: 'long',


### PR DESCRIPTION
Hi Christoph,

I’ve fixed the bug related to the 'Today time' being hardcoded to 7 PM. The issue has been resolved by replacing the hardcoded value with a dynamic variable that retrieves the time of the upcoming event. Currently, the time is displayed in AM/PM format. If you'd prefer to use a 24-hour format for simplicity and consistency, I can easily make that adjustment.

I’ve attached a video for clarity. If you have any comments or feedback, please feel free to let me know, and I’ll make the necessary changes.

Link to the video:
https://github.com/user-attachments/assets/0da0bd9e-c14f-46b5-9c09-902bc066043d