### PR TITLE
Fix add the missing time to the next event when the event is not today.

### DIFF
--- a/src/components/NextEvent.tsx
+++ b/src/components/NextEvent.tsx
@@ -78,11 +78,11 @@ export default function NextEvent() {
         <em>
           {isEventToday
             ? `Today ${eventTime}`
-            : eventDate.toLocaleString('en-us', {
+            : `${eventDate.toLocaleString('en-us', {
               day: 'numeric',
               month: 'long',
               year: 'numeric',
-            })}
+            })} - ${eventTime}`}
         </em>
       </h2>
       <div className="venue">


### PR DESCRIPTION
@janis-kra 

Hi, I hope you're doing well! 😊

I updated the logic to include the event time even when the event is not today. Previously, the Event-Time variable was created but only used for events happening today. Now, the same value is used for events on other days as well.

Feel free to reach out if you have any questions or need clarification.

[Video](https://drive.google.com/file/d/1ce5F_1RjbCOK9dOvbn3y7G7IPOTCYEMD/view)